### PR TITLE
Update to latest libraries and use XCommon CMake

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,5 @@ examples/AN01032_100Mbit_avb_i2s_demo/doc/pdf/
 .*.swp
 .settings
 */doc/pdf/tsn.pdf
+examples/AN01032_100Mbit_avb_i2s_demo/src/aem_descriptors.generated/aem_descriptors.h
+examples/AN01032_100Mbit_avb_i2s_demo/src/aem_descriptors.generated/aem_entity_strings.h

--- a/examples/AN00202_gige_avb_i2s_demo/CMakeLists.txt
+++ b/examples/AN00202_gige_avb_i2s_demo/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.21)
 include($ENV{XMOS_CMAKE_PATH}/xcommon.cmake)
-project(app_100Mbit_avb_i2s_demo)
+project(app_gige_avb_i2s_demo)
 
 set(APP_HW_TARGET           SLICEKIT-ETH-TRIANGLE1-PLL-TRIANGLE0.xn)
 

--- a/examples/AN00203_gige_avb_tdm_demo/CMakeLists.txt
+++ b/examples/AN00203_gige_avb_tdm_demo/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.21)
 include($ENV{XMOS_CMAKE_PATH}/xcommon.cmake)
-project(app_100Mbit_avb_i2s_demo)
+project(app_gige_avb_tdm_demo)
 
 set(APP_HW_TARGET           SLICEKIT-ETH-TRIANGLE1-PLL-TRIANGLE0.xn)
 

--- a/examples/AN01032_100Mbit_avb_i2s_demo/CMakeLists.txt
+++ b/examples/AN01032_100Mbit_avb_i2s_demo/CMakeLists.txt
@@ -1,0 +1,40 @@
+cmake_minimum_required(VERSION 3.21)
+include($ENV{XMOS_CMAKE_PATH}/xcommon.cmake)
+project(app_avb_i2s_demo)
+
+set(APP_HW_TARGET           SLICEKIT-ETH-TRIANGLE1-PLL-TRIANGLE0.xn)
+
+set(APP_DEPENDENT_MODULES   "lib_tsn(8.0.0)"
+                            "lib_i2s(6.0.1)")
+
+set(APP_COMPILER_FLAGS      -Os
+                            -g
+                            -report
+                            -lquadflash)
+
+set(APP_XSCOPE_SRCS         src/config.xscope)
+set(APP_INCLUDES            src)
+
+set(XMOS_SANDBOX_DIR        ${CMAKE_CURRENT_LIST_DIR}/../../..)
+
+# Legacy lib with no XCCM support
+set(XMOS_DEP_DIR_lib_gpio ${XMOS_SANDBOX_DIR}/lib_gpio)
+if(NOT EXISTS ${XMOS_SANDBOX_DIR}/lib_gpio)
+    include(FetchContent)
+    FetchContent_Declare(
+        lib_gpio
+        GIT_REPOSITORY git@github.com:xmos/lib_gpio
+        GIT_TAG develop
+        SOURCE_DIR ${XMOS_SANDBOX_DIR}/lib_gpio
+    )
+    FetchContent_Populate(lib_gpio)
+endif()
+
+# list(APPEND APP_DEPENDENT_MODULES "lib_gpio") # Can't do this yet as no XCCM branch
+file(GLOB_RECURSE SOURCES_XC_APP RELATIVE   ${CMAKE_CURRENT_LIST_DIR} "src/*.xc")
+file(GLOB_RECURSE SOURCES_XC_GPIO RELATIVE  ${CMAKE_CURRENT_LIST_DIR} "src/*.xc")
+set(APP_XC_SRCS                             ${SOURCES_XC_APP} ${SOURCES_XC_GPIO})
+list(APPEND APP_INCLUDES                    ../../../lib_gpio/lib_gpio/api)
+
+
+XMOS_REGISTER_APP()

--- a/examples/AN01032_100Mbit_avb_i2s_demo/CMakeLists.txt
+++ b/examples/AN01032_100Mbit_avb_i2s_demo/CMakeLists.txt
@@ -28,24 +28,5 @@ execute_process(
     COMMAND echo "running python AEM generate"
     WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
 
-# Legacy lib with no XCCM support. Fetch and build from source
-set(XMOS_DEP_DIR_lib_gpio ${XMOS_SANDBOX_DIR}/lib_gpio)
-if(NOT EXISTS ${XMOS_SANDBOX_DIR}/lib_gpio)
-    include(FetchContent)
-    FetchContent_Declare(
-        lib_gpio
-        GIT_REPOSITORY git@github.com:xmos/lib_gpio
-        GIT_TAG develop
-        SOURCE_DIR ${XMOS_SANDBOX_DIR}/lib_gpio
-    )
-    FetchContent_Populate(lib_gpio)
-endif()
-
-# list(APPEND APP_DEPENDENT_MODULES "lib_gpio") # Can't do this yet as no XCCM branch
-file(GLOB_RECURSE SOURCES_XC_APP RELATIVE   ${CMAKE_CURRENT_LIST_DIR} "src/*.xc")
-file(GLOB_RECURSE SOURCES_XC_GPIO RELATIVE  ${CMAKE_CURRENT_LIST_DIR} "src/*.xc")
-set(APP_XC_SRCS                             ${SOURCES_XC_APP} ${SOURCES_XC_GPIO})
-list(APPEND APP_INCLUDES                    ../../../lib_gpio/lib_gpio/api)
-
 
 XMOS_REGISTER_APP()

--- a/examples/AN01032_100Mbit_avb_i2s_demo/CMakeLists.txt
+++ b/examples/AN01032_100Mbit_avb_i2s_demo/CMakeLists.txt
@@ -7,17 +7,28 @@ set(APP_HW_TARGET           SLICEKIT-ETH-TRIANGLE1-PLL-TRIANGLE0.xn)
 set(APP_DEPENDENT_MODULES   "lib_tsn(8.0.0)"
                             "lib_i2s(6.0.1)")
 
+
 set(APP_COMPILER_FLAGS      -Os
                             -g
                             -report
                             -lquadflash)
 
+set(APP_COMPILER_FLAGS_main.xc ${APP_COMPILER_FLAGS} -falways-inline -O3)
+
 set(APP_XSCOPE_SRCS         src/config.xscope)
-set(APP_INCLUDES            src)
+set(APP_INCLUDES            src
+                            src/aem_descriptors.generated)
 
 set(XMOS_SANDBOX_DIR        ${CMAKE_CURRENT_LIST_DIR}/../../..)
 
-# Legacy lib with no XCCM support
+
+# Run AEM descriptor script
+execute_process(
+    COMMAND python2 ${CMAKE_CURRENT_LIST_DIR}/src/generate.py ${CMAKE_CURRENT_LIST_DIR}/src/ ${CMAKE_CURRENT_LIST_DIR}/src/aem_descriptors.generated/
+    COMMAND echo "running python AEM generate"
+    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
+
+# Legacy lib with no XCCM support. Fetch and build from source
 set(XMOS_DEP_DIR_lib_gpio ${XMOS_SANDBOX_DIR}/lib_gpio)
 if(NOT EXISTS ${XMOS_SANDBOX_DIR}/lib_gpio)
     include(FetchContent)

--- a/examples/AN01032_100Mbit_avb_i2s_demo/Makefile
+++ b/examples/AN01032_100Mbit_avb_i2s_demo/Makefile
@@ -34,7 +34,7 @@ XCC_FLAGS_main.xc = $(XCC_FLAGS) -falways-inline -O3
 
 # The USED_MODULES variable lists other module used by the application.
 
-USED_MODULES = lib_tsn(>=8.0.0) lib_i2s(>=2.3.0)
+USED_MODULES = lib_tsn(>=8.0.0) lib_i2s(>=2.3.0) lib_gpio
 
 VERBOSE=0
 

--- a/examples/AN01032_100Mbit_avb_i2s_demo/src/generate.py
+++ b/examples/AN01032_100Mbit_avb_i2s_demo/src/generate.py
@@ -62,3 +62,13 @@ def main():
     print "AEM descriptor header file generation complete"
 
 main()
+
+# ensure we exit cleanly when we run from cmake
+try:
+    sys.stdout.close()
+except:
+    pass
+try:
+    sys.stderr.close()
+except:
+    pass

--- a/examples/AN01032_100Mbit_avb_i2s_demo/src/generate.py
+++ b/examples/AN01032_100Mbit_avb_i2s_demo/src/generate.py
@@ -47,6 +47,8 @@ def do_replace(read_file, write_file, replace_defines):
 def main():
     srcpath = sys.argv[1]
     dstpath = sys.argv[2]
+    if not os.path.exists(dstpath):
+        os.makedirs(dstpath)
     read_file = open(os.path.join(srcpath, 'aem_descriptors.h.in'), 'r')
     write_file = open(os.path.join(dstpath, 'aem_descriptors.h'), 'w')
 

--- a/examples/AN01032_100Mbit_avb_i2s_demo/src/main.xc
+++ b/examples/AN01032_100Mbit_avb_i2s_demo/src/main.xc
@@ -31,6 +31,7 @@ fl_QSPIPorts qspi_ports =
 };
 
 
+
 in port p_rxclk = PORT_ETH_RXCLK;
 in port p_rxer  = PORT_ETH_RXER; 
 in port p_rxd   = PORT_ETH_RXD; 
@@ -78,7 +79,7 @@ void buffer_manager_to_i2s(server i2s_frame_callback_if i2s,
 {
   audio_frame_t *unsafe p_in_frame;
   audio_double_buffer_t *unsafe double_buffer;
-  int32_t *unsafe sample_out_buf;
+  int32_t *unsafe sample_out_buf = NULL;
   unsigned cur_sample_rate;
   timer tmr;
 
@@ -189,8 +190,10 @@ void buffer_manager_to_i2s(server i2s_frame_callback_if i2s,
     case i2s.restart_check() -> i2s_restart_t restart:
 
       unsafe {
-        if (sample_out_buf[8]) {
-          restart = I2S_RESTART;
+        /* Ensure we have received our first sample buf first and then
+           check for magic value which indicates a sample rate change */
+        if (sample_out_buf != NULL && sample_out_buf[AVB_NUM_MEDIA_INPUTS + AVB_NUM_MEDIA_OUTPUTS]) {
+          restart = I2S_RESTART;        
           while (!stestct(c_audio)) {
             c_audio :> int;
           }
@@ -212,15 +215,16 @@ void buffer_manager_to_i2s(server i2s_frame_callback_if i2s,
 
     case i2s.send(size_t num_out, int32_t samples[num_out]):
       unsafe{
+        c_audio :> sample_out_buf;        
         for(int index = 0; index < num_out; index++){
           samples[index] = sample_out_buf[index];
         }
         
-        c_audio :> sample_out_buf;
         tmr :> p_in_frame->timestamp;
         audio_frame_t *unsafe new_frame = audio_buffers_swap_active_buffer(*double_buffer);
         c_audio <: p_in_frame;
         p_in_frame = new_frame;
+        
       }
       break; // End of send
     }

--- a/examples/AN01032_100Mbit_avb_i2s_demo/src/main.xc
+++ b/examples/AN01032_100Mbit_avb_i2s_demo/src/main.xc
@@ -389,7 +389,6 @@ int main(void)
 
 
     on tile[0]: {
-      set_core_high_priority_on();
       i2s_frame_master(i_i2s,
                  p_aud_dout, AVB_NUM_MEDIA_OUTPUTS/2,
                  p_aud_din, AVB_NUM_MEDIA_INPUTS/2,

--- a/examples/AN01032_100Mbit_avb_i2s_demo/src/main.xc
+++ b/examples/AN01032_100Mbit_avb_i2s_demo/src/main.xc
@@ -4,7 +4,7 @@
 #include <print.h>
 #include <string.h>
 #include <xscope.h>
-#include "gpio.h"
+// #include "gpio.h"
 #include "i2s.h"
 #include "i2c.h"
 #include "avb.h"
@@ -48,12 +48,11 @@ port p_sda = PORT_AUD_SDA;
 
 out buffered port:32 p_fs[1] = { PORT_AUD_PLL }; // Low frequency PLL frequency reference
 out buffered port:32 p_i2s_lrclk = PORT_AUD_LRCLK;
-out buffered port:32 p_i2s_bclk = PORT_AUD_SCLK;
+out port p_i2s_bclk = PORT_AUD_SCLK;
 in port p_i2s_mclk = PORT_AUD_MCLK;
 out buffered port:32 p_aud_dout[2] = {PORT_AUD_DAC0, PORT_AUD_DAC1};
 in buffered port:32 p_aud_din[2] = {PORT_AUD_ADC0, PORT_AUD_ADC1};
 clock clk_i2s_bclk = on tile[0]: XS1_CLKBLK_2;
-clock clk_i2s_mclk = on tile[0]: XS1_CLKBLK_3;
 out port p_codec_rst_leds = PORT_AUD_CTRL;
 
 // I2C addresses for the CODECS
@@ -72,7 +71,7 @@ const int codec2_addr = 0x49;
 
 #pragma unsafe arrays
 [[always_inline]][[distributable]]
-void buffer_manager_to_i2s(server i2s_callback_if i2s,
+void buffer_manager_to_i2s(server i2s_frame_callback_if i2s,
                            streaming chanend c_audio,
                            client interface i2c_master_if i2c,
                            out port p_codec_rst_leds)
@@ -203,25 +202,25 @@ void buffer_manager_to_i2s(server i2s_callback_if i2s,
       }
       break; // End of restart check
 
-    case i2s.receive(size_t index, int32_t sample):
-      unsafe {
-        p_in_frame->samples[index] = sample;
+    case i2s.receive(size_t num_in, int32_t samples[num_in]):
+      for(int index = 0; index < num_in; index++){
+        unsafe {
+          p_in_frame->samples[index] = samples[index];
+        }
       }
       break;
 
-    case i2s.send(size_t index) -> int32_t sample:
-    
-     unsafe {
-        if (index == 0) {
-          c_audio :> sample_out_buf;
+    case i2s.send(size_t num_out, int32_t samples[num_out]):
+      unsafe{
+        for(int index = 0; index < num_out; index++){
+          samples[index] = sample_out_buf[index];
         }
-        sample = sample_out_buf[index];
-        if (index == (AVB_NUM_MEDIA_INPUTS-1)) {
-          tmr :> p_in_frame->timestamp;
-          audio_frame_t *unsafe new_frame = audio_buffers_swap_active_buffer(*double_buffer);
-          c_audio <: p_in_frame;
-          p_in_frame = new_frame;
-        }
+        
+        c_audio :> sample_out_buf;
+        tmr :> p_in_frame->timestamp;
+        audio_frame_t *unsafe new_frame = audio_buffers_swap_active_buffer(*double_buffer);
+        c_audio <: p_in_frame;
+        p_in_frame = new_frame;
       }
       break; // End of send
     }
@@ -344,7 +343,7 @@ int main(void)
   i2c_master_if i_i2c[NUM_I2C_IFS];
 
   // I2S and audio buffering interfaces
-  i2s_callback_if i_i2s;
+  i2s_frame_callback_if i_i2s;
   streaming chan c_audio;
   interface push_if i_audio_in_push;
   interface pull_if i_audio_in_pull;
@@ -387,15 +386,14 @@ int main(void)
 
     on tile[0]: {
       set_core_high_priority_on();
-      configure_clock_src(clk_i2s_mclk, p_i2s_mclk);
-      start_clock(clk_i2s_mclk);
-      i2s_master(i_i2s,
+      i2s_frame_master(i_i2s,
                  p_aud_dout, AVB_NUM_MEDIA_OUTPUTS/2,
                  p_aud_din, AVB_NUM_MEDIA_INPUTS/2,
+                 32,
                  p_i2s_bclk,
                  p_i2s_lrclk,
-                 clk_i2s_bclk,
-                 clk_i2s_mclk);
+                 p_i2s_mclk,
+                 clk_i2s_bclk);
     }
 
     on tile[0]: [[distribute]] buffer_manager_to_i2s(i_i2s, c_audio, i_i2c[I2S_TO_I2C], p_codec_rst_leds);
@@ -422,7 +420,11 @@ int main(void)
     on tile[0]: {
       char mac_address[6];
       if (otp_board_info_get_mac(otp_ports0, 0, mac_address) == 0) {
-        fail("No MAC address programmed in OTP");
+        const char mac_address_manual[] = {0x12, 0x34, 0x56, 0x67, 0x89, 0xab};
+        debug_printf("No MAC address programmed in OTP, falling back to %x:%x:%x:%x:%x:%x\n",
+            mac_address_manual[0], mac_address_manual[1], mac_address_manual[2],
+            mac_address_manual[3], mac_address_manual[4], mac_address_manual[5]);
+        memcpy(mac_address, mac_address_manual, sizeof(mac_address));
       }
       i_eth_cfg[MAC_CFG_TO_AVB_MANAGER].set_macaddr(0, mac_address);
       [[combine]]

--- a/lib_tsn/lib_build_info.cmake
+++ b/lib_tsn/lib_build_info.cmake
@@ -1,6 +1,6 @@
 set(LIB_NAME lib_tsn)
 set(LIB_VERSION 8.0.0)
-set(LIB_DEPENDENT_MODULES   "lib_ethernet(4.0.0)"
+set(LIB_DEPENDENT_MODULES   "lib_ethernet(develop)"
                             "lib_i2c(6.4.0)"
                             "lib_logging(2.1.0)"
                             "lib_xassert(4.3.1)"

--- a/lib_tsn/lib_build_info.cmake
+++ b/lib_tsn/lib_build_info.cmake
@@ -14,11 +14,11 @@ set(LIB_OPTIONAL_HEADERS    "ethernet_conf.h"
 set(LIB_COMPILER_FLAGS      -g
                             -Os)
 
-set(LIB_COMPILER_FLAGS_media_clock_server.xc ${LIB_COMPILER_FLAGS} -g -O3)
-set(LIB_COMPILER_FLAGS_audio_output_fifo.c ${LIB_COMPILER_FLAGS} -O3)
-set(LIB_COMPILER_FLAGS_avb_1722_talker_support_audio.c ${LIB_COMPILER_FLAGS} -O3)
-set(LIB_COMPILER_FLAGS_audio_buffering.xc ${LIB_COMPILER_FLAGS} -O3)
-set(LIB_COMPILER_FLAGS_avb_1722_talker.xc ${LIB_COMPILER_FLAGS} -O3)
+set(LIB_COMPILER_FLAGS_media_clock_server.xc            ${LIB_COMPILER_FLAGS} -g -O3)
+set(LIB_COMPILER_FLAGS_audio_output_fifo.c              ${LIB_COMPILER_FLAGS} -O3)
+set(LIB_COMPILER_FLAGS_avb_1722_talker_support_audio.c  ${LIB_COMPILER_FLAGS} -O3)
+set(LIB_COMPILER_FLAGS_audio_buffering.xc               ${LIB_COMPILER_FLAGS} -O3)
+set(LIB_COMPILER_FLAGS_avb_1722_talker.xc               ${LIB_COMPILER_FLAGS} -O3)
 
 set(LIB_INCLUDES            api
                             src

--- a/lib_tsn/lib_build_info.cmake
+++ b/lib_tsn/lib_build_info.cmake
@@ -1,0 +1,37 @@
+set(LIB_NAME lib_tsn)
+set(LIB_VERSION 8.0.0)
+set(LIB_DEPENDENT_MODULES   "lib_ethernet(4.0.0)"
+                            "lib_i2c(6.4.0)"
+                            "lib_logging(2.1.0)"
+                            "lib_xassert(4.3.1)"
+                            "lib_otpinfo(2.1.0)"
+                            "lib_random(1.2.0)")
+
+set(LIB_OPTIONAL_HEADERS    "ethernet_conf.h"
+                            "random_conf.h"
+                            "avb_conf.h")
+
+set(LIB_COMPILER_FLAGS      -g
+                            -Os)
+
+set(LIB_COMPILER_FLAGS_media_clock_server.xc ${LIB_COMPILER_FLAGS} -g -O3)
+set(LIB_COMPILER_FLAGS_audio_output_fifo.c ${LIB_COMPILER_FLAGS} -O3)
+set(LIB_COMPILER_FLAGS_avb_1722_talker_support_audio.c ${LIB_COMPILER_FLAGS} -O3)
+set(LIB_COMPILER_FLAGS_audio_buffering.xc ${LIB_COMPILER_FLAGS} -O3)
+set(LIB_COMPILER_FLAGS_avb_1722_talker.xc ${LIB_COMPILER_FLAGS} -O3)
+
+set(LIB_INCLUDES            api
+                            src
+                            src/util
+                            src/srp
+                            src/ptp
+                            src/media_clock
+                            src/media_clock/external_hw/CS2100CP
+                            src/media_clock/external_hw/CS2300CP
+                            src/avb
+                            src/audio_buffering
+                            src/1722_1
+                            src/1722
+                            src/1722/maap)
+
+XMOS_REGISTER_MODULE()


### PR DESCRIPTION
Main change is move to lib_i2s frame which is much more efficient.
XCommon cmake support for lib and examples
Uses develop of lib_ethernet for now (version 4.0.0 which is being updated to add RMII and has new SMI implementation)